### PR TITLE
Remove redundant Drupal module download.

### DIFF
--- a/tasks/build-fits-site.yml
+++ b/tasks/build-fits-site.yml
@@ -71,11 +71,3 @@
   when: crayfits.stat.exists == False
   become: true
 
-- name: Download Islandora FITS
-  composer:
-    command: require
-    arguments: islandora-rdm/islandora_fits
-    working_dir: "{{ drupal_core_path }}/.."
-
-- name: Enable Islansdora FITS
-  command: "{{ drush_path }} --root {{ drupal_core_path }} -y en islandora_fits"


### PR DESCRIPTION
**GitHub Issue**: (link)

https://github.com/Islandora/documentation/issues/1638

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Removes invocations of composer and drush attempting to install the islandora_fits Drupal module from the Ansible role. This composer invocation is causing an out-of-memory error when I attempt a Vagrant provision.

The module is downloaded and installed in the webserver/drupal.yml inventory tasks already so this is also redundant. See: https://github.com/Islandora-Devops/islandora-playbook/blob/dev/inventory/vagrant/group_vars/webserver/drupal.yml#L23

# What's new?

* Ansible commands that invoke composer and drush are removed.


# How should this be tested?

* Run an ansible build and observe that the composer stop that was causing the out-of-memory error no longer runs and Ansible is able to continue past the role.

# Additional Notes:

I intend to also make a request to point the playbook requirements.yml at the '8.x-1.x' branch of islandora_fits, and then subsequently to get it moved to the islandora Github repo but for now this change fixes the Vagrant crash.

# Interested parties
@ajstanley  @Islandora-Devops/committers
