### PR TITLE
Update to run on Tomcat 9 and Ubuntu 20.04 Focal64

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ fits_install_symlink: /opt/fits
 
 User/group to install as:
 ```
-fits_user: tomcat8
-fits_group: tomcat8
+fits_user: tomcat
+fits_group: tomcat
 ```
 
 Install the FITS web service in Tomcat

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,8 @@ fits_version: 1.4.1
 fits_ws_version: 1.2.0
 fits_install_root: /opt
 fits_install_symlink: /opt/fits
-fits_user: tomcat8
-fits_group: tomcat8
+fits_user: tomcat
+fits_group: tomcat
 fits_ws: yes
 crayfits_home: /var/www/html
 fits_src_url: "https://github.com/harvard-lts/fits/releases/download/{{ fits_version }}/fits-{{ fits_version }}.zip"

--- a/tasks/config-ws.yml
+++ b/tasks/config-ws.yml
@@ -1,24 +1,24 @@
 # TODO: find a better way here, this is ugly and will bite us
 - name: Set fits.home in catalina.properties
   lineinfile:
-    path: "{{ tomcat8_home }}/conf/catalina.properties"
+    path: "{{ tomcat9_home }}/conf/catalina.properties"
     regexp: "^fits.home="
     line: "fits.home={{ fits_install_symlink }}"
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: Set shared.loader in catalina.properties
   lineinfile:
-    path: "{{ tomcat8_home }}/conf/catalina.properties"
+    path: "{{ tomcat9_home }}/conf/catalina.properties"
     line: 'shared.loader=${fits.home}/lib/*.jar'
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: Wait for FITS to finish coming back up
   wait_for:
-    path: "{{ tomcat8_home }}/webapps/fits/WEB-INF/classes"
+    path: "{{ tomcat9_home }}/webapps/fits/WEB-INF/classes"
     state: present
 
 - name: Configure FITS web service logging
   template:
     src: log4j.properties.j2
-    dest: "{{ tomcat8_home }}/webapps/fits/WEB-INF/classes/log4j.properties"
-  notify: restart tomcat8
+    dest: "{{ tomcat9_home }}/webapps/fits/WEB-INF/classes/log4j.properties"
+  notify: restart tomcat9

--- a/tasks/install-ws.yml
+++ b/tasks/install-ws.yml
@@ -3,7 +3,7 @@
 - name: "Install FITS web service {{ansible_os_family}}"
   get_url:
     url: http://projects.iq.harvard.edu/files/fits/files/fits-{{ fits_ws_version }}.war
-    dest: "{{ tomcat8_home }}/webapps/fits.war"
+    dest: "{{ tomcat9_home }}/webapps/fits.war"
     owner: "{{ fits_user }}"
     group: "{{ fits_group }}"
     checksum: "{{fits_ws_md5sum}}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,8 +4,8 @@
   file:
     path: "{{ fits_install_root }}/fits-{{ fits_version }}"
     state: directory
-    owner: tomcat8
-    group: tomcat8
+    owner: tomcat
+    group: tomcat
     mode: 0700
 
 - name: Downloading FITS executables

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,6 @@
 
 httpd_conf_directory: "/etc/apache2"
 httpd_conf_directory_enabled: "{{httpd_conf_directory}}/conf-enabled"
-fits_log_path: /var/log/tomcat8
+fits_log_path: /var/log/tomcat9
 apache_service: apache2
 apache_restart_state: restarted


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64 #](https://github.com/Islandora/documentation/issues/1792)

# What does this Pull Request do?

Update to run on Tomcat 9 and Ubuntu 20.04.

# What's new?

Update references to Tomcat 8 to Tomcat 9, and the new tomcat user, 'tomcat'.

# How should this be tested?

Test as part of a full Ubuntu Focal64 build. Fits should deploy and run as expected to add image metadata to Islandora objects.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
